### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/server/routes/employee.routes.js
+++ b/server/routes/employee.routes.js
@@ -8,7 +8,12 @@ const deleteEmployeeLimiter = rateLimit({
     max: 50, // limit each IP to 50 requests per windowMs
 });
 
-router.get('/', employee.getEmployees);
+const getEmployeesLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
+router.get('/', getEmployeesLimiter, employee.getEmployees);
 router.post('/', employee.createEmployee);
 const getEmployeeLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes


### PR DESCRIPTION
Potential fix for [https://github.com/ChayoVS/mean-crud/security/code-scanning/6](https://github.com/ChayoVS/mean-crud/security/code-scanning/6)

To fix the issue, we will apply rate limiting to the `employee.getEmployees` route using the `express-rate-limit` package, which is already imported in the file. We will define a new rate limiter specifically for this route, similar to the existing limiters for other routes. The rate limiter will restrict the number of requests from each IP address to a reasonable limit within a specified time window.

**Steps:**
1. Define a new rate limiter for the `employee.getEmployees` route.
2. Apply the rate limiter to the route by adding it as middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
